### PR TITLE
Gem upgrade, removed ActiveSupport::CoreExtensions.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,14 @@
 source "http://rubygems.org"
-# Add dependencies required to use your gem here.
-# Example:
-#   gem "activesupport", ">= 2.3.5"
-gem "partialruby", ">= 0.2.0"
-gem "ruby_parser", ">= 2.0.6"
+
+gem "partialruby", "~> 0.2.2"
+gem "ruby_parser", "~> 2.0"
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 group :development do
   gem "shoulda", ">= 0"
-  gem "bundler", "~> 1.0.0"
+  gem "bundler", "~> 1.2.0"
   gem "jeweler", "~> 1.6.1"
   gem "simplecov", ">= 0"
+  gem "activesupport", "~> 3.2.10"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -43,7 +43,7 @@ end
 
 task :default => :test
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/lib/sandboxed_erb.rb
+++ b/lib/sandboxed_erb.rb
@@ -31,7 +31,7 @@ require "sandboxed_erb/system_mixins"
 module SandboxedErb
   class Error < ::StandardError #:nodoc: all
   end
-  
+
   class CompileError < Error #:nodoc: all
   end
   class CompileSecurityError < Error #:nodoc: all

--- a/lib/sandboxed_erb/system_mixins.rb
+++ b/lib/sandboxed_erb/system_mixins.rb
@@ -21,32 +21,16 @@ along with shikashi.  if not, see <http://www.gnu.org/licenses/>.
 
 
 #add sandboxed method to basic inbuilt objects
-if defined? ActiveSupport
-  String.not_sandboxed_methods true, [ActiveSupport::CoreExtensions::String::Iterators,ActiveSupport::CoreExtensions::String::StartsEndsWith, ActiveSupport::CoreExtensions::String::Inflections, ActiveSupport::CoreExtensions::String::Conversions, Comparable, Enumerable], :bang_methods
-  Fixnum.not_sandboxed_methods true, [ActiveSupport::CoreExtensions::Integer::Inflections, ActiveSupport::CoreExtensions::Integer::EvenOdd,ActiveSupport::CoreExtensions::Numeric::Bytes, ActiveSupport::CoreExtensions::Numeric::Time, Comparable], :bang_methods
-  Float.not_sandboxed_methods true, [ActiveSupport::CoreExtensions::Numeric::Bytes, ActiveSupport::CoreExtensions::Numeric::Time, Comparable], :bang_methods
-  Range.not_sandboxed_methods true, [ActiveSupport::CoreExtensions::Range::Conversions, Enumerable], :bang_methods
-  Symbol.not_sandboxed_methods true
-  Time.not_sandboxed_methods true, [ActiveSupport::CoreExtensions::Time::Conversions, ActiveSupport::CoreExtensions::Time::Calculations, Comparable], :bang_methods
-  Date.not_sandboxed_methods true, [ActiveSupport::CoreExtensions::Date::Conversions, Comparable], :bang_methods
-  DateTime.not_sandboxed_methods true, [ActiveSupport::CoreExtensions::Date::Conversions, Comparable], :bang_methods
-  NilClass.not_sandboxed_methods true
-  Array.not_sandboxed_methods true, [ActiveSupport::CoreExtensions::Array::Grouping, ActiveSupport::CoreExtensions::Array::Conversions, Enumerable], :bang_methods
-  Hash.not_sandboxed_methods true, [ActiveSupport::CoreExtensions::Hash::Diff, ActiveSupport::CoreExtensions::Hash::Conversions, ActiveSupport::CoreExtensions::Hash::ReverseMerge, ActiveSupport::CoreExtensions::Hash::IndifferentAccess, ActiveSupport::CoreExtensions::Hash::Keys, Enumerable], :bang_methods
-  FalseClass.not_sandboxed_methods true
-  TrueClass.not_sandboxed_methods true
-else
-  String.not_sandboxed_methods true, [Comparable, Enumerable], :bang_methods
-  Fixnum.not_sandboxed_methods true, [Comparable], :bang_methods
-  Float.not_sandboxed_methods true, [Comparable], :bang_methods
-  Range.not_sandboxed_methods true, [Enumerable], :bang_methods
-  Symbol.not_sandboxed_methods true
-  Time.not_sandboxed_methods true, [Comparable], :bang_methods
-  Date.not_sandboxed_methods true, [Comparable], :bang_methods
-  DateTime.not_sandboxed_methods true, [Comparable], :bang_methods
-  NilClass.not_sandboxed_methods true
-  Array.not_sandboxed_methods true, [Enumerable], :bang_methods
-  Hash.not_sandboxed_methods true, [Enumerable], :bang_methods
-  FalseClass.not_sandboxed_methods true
-  TrueClass.not_sandboxed_methods true
-end
+String.not_sandboxed_methods true, [Comparable, Enumerable], :bang_methods
+Fixnum.not_sandboxed_methods true, [Comparable], :bang_methods
+Float.not_sandboxed_methods true, [Comparable], :bang_methods
+Range.not_sandboxed_methods true, [Enumerable], :bang_methods
+Symbol.not_sandboxed_methods true
+Time.not_sandboxed_methods true, [Comparable], :bang_methods
+Date.not_sandboxed_methods true, [Comparable], :bang_methods
+DateTime.not_sandboxed_methods true, [Comparable], :bang_methods
+NilClass.not_sandboxed_methods true
+Array.not_sandboxed_methods true, [Enumerable], :bang_methods
+Hash.not_sandboxed_methods true, [Enumerable], :bang_methods
+FalseClass.not_sandboxed_methods true
+TrueClass.not_sandboxed_methods true

--- a/sandboxed_erb.gemspec
+++ b/sandboxed_erb.gemspec
@@ -4,14 +4,14 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{sandboxed_erb}
+  s.name = "sandboxed_erb"
   s.version = "0.4.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["MarkPent"]
-  s.date = %q{2012-03-20}
-  s.description = %q{Run erb templates safely within a sandbox.}
-  s.email = %q{mark.pent@gmail.com}
+  s.date = "2013-01-08"
+  s.description = "Run erb templates safely within a sandbox."
+  s.email = "mark.pent@gmail.com"
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.rdoc"
@@ -43,11 +43,11 @@ Gem::Specification.new do |s|
     "test/test_sandboxed_erb.rb",
     "test/test_valid_templates.rb"
   ]
-  s.homepage = %q{http://github.com/markpent/SandboxedERB}
+  s.homepage = "http://github.com/markpent/SandboxedERB"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.5.2}
-  s.summary = %q{Run an erb template in a sandbox.}
+  s.rubygems_version = "1.8.24"
+  s.summary = "Run an erb template in a sandbox."
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
@@ -56,14 +56,14 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<partialruby>, [">= 0.2.0"])
       s.add_runtime_dependency(%q<ruby_parser>, [">= 2.0.6"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
-      s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
+      s.add_development_dependency(%q<bundler>, ["~> 1.2.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.1"])
       s.add_development_dependency(%q<simplecov>, [">= 0"])
     else
       s.add_dependency(%q<partialruby>, [">= 0.2.0"])
       s.add_dependency(%q<ruby_parser>, [">= 2.0.6"])
       s.add_dependency(%q<shoulda>, [">= 0"])
-      s.add_dependency(%q<bundler>, ["~> 1.0.0"])
+      s.add_dependency(%q<bundler>, ["~> 1.2.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.6.1"])
       s.add_dependency(%q<simplecov>, [">= 0"])
     end
@@ -71,7 +71,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<partialruby>, [">= 0.2.0"])
     s.add_dependency(%q<ruby_parser>, [">= 2.0.6"])
     s.add_dependency(%q<shoulda>, [">= 0"])
-    s.add_dependency(%q<bundler>, ["~> 1.0.0"])
+    s.add_dependency(%q<bundler>, ["~> 1.2.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.6.1"])
     s.add_dependency(%q<simplecov>, [">= 0"])
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,6 +10,8 @@ end
 require 'test/unit'
 require 'shoulda'
 
+require 'active_support'
+
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'sandboxed_erb'


### PR DESCRIPTION
It looks like ActiveSupport was completely refactored to get rid of those extension modules, all the methods in `core_ext` are just declared on the opened up classes. This makes `sandboxed_erb` load with an error: "undefined class ActiveSupport::CoreExtensions".  I think the right thing to do is to get rid of the custom code that deals with this.

Other gem upgrades here too that make all tests pass.
